### PR TITLE
use vagrant-librarian-puppet plugin instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Vagrant 1.4+ is required for the private networking feature to work.
 
 For the local install, we are using the [Puppet Labs](http://puppet-vagrant-boxes.puppetlabs.com/) CentOS box. For the remote install, we are using the newest Amazon Linux AMI. CentOS and Amazon Linux are reasonably similar, and are binary- and package-compatible.
 
-We run [librarian-puppet](http://librarian-puppet.com/) to fetch Puppet modules and dependencies once the VM has booted.
+We run [librarian-puppet](http://librarian-puppet.com/) to fetch Puppet modules and dependencies once the VM has booted.  This work is performed by the [vagrant-librarian-puppet](https://github.com/mhahn/vagrant-librarian-puppet) Vagrant plugin; before proceeding, you must install this plugin by running `vagrant plugin install vagrant-librarian-puppet`.
 
 Local install using VirtualBox
 ------------------------------

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,10 +7,4 @@ if [ ! -x /usr/bin/git ]; then
   sleep 4
 fi
 
-if [ "$(gem query -i -n librarian-puppet)" != "true" ]; then
-  gem install --no-rdoc --no-ri librarian-puppet -v 1.0.3
-  cd /vagrant && librarian-puppet install --clean --verbose
-else
-  cd /vagrant && librarian-puppet update --verbose
-fi
 # vim: set ft=sh ts=2 sw=2 ei:


### PR DESCRIPTION
yes, it adds another external dependency, but on the other hand our script was throwing errors on my test system, and the external plugin just worked out of the box.
